### PR TITLE
upgrade chart versions

### DIFF
--- a/charts/bitnami/external-dns.yml
+++ b/charts/bitnami/external-dns.yml
@@ -1,1 +1,1 @@
-version: 1.5.2
+version: 2.3.1

--- a/charts/jenkins-x/jenkins-x-platform.yml
+++ b/charts/jenkins-x/jenkins-x-platform.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x/jenkins-x-platform
-version: 2.0.768
+version: 2.0.851

--- a/charts/jenkins-x/jx-build-templates.yml
+++ b/charts/jenkins-x/jx-build-templates.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/jx-build-templates
-version: 0.0.771
+version: 0.0.795

--- a/charts/jenkins-x/prow.yml
+++ b/charts/jenkins-x/prow.yml
@@ -1,2 +1,2 @@
 gitUrl: https://github.com/jenkins-x-charts/prow
-version: 0.0.879
+version: 0.0.925

--- a/charts/stable/external-dns.yml
+++ b/charts/stable/external-dns.yml
@@ -1,2 +1,2 @@
-version: 1.5.2
 gitUrl: https://github.com/bitnami/charts/tree/master/bitnami/external-dns
+version: 2.3.1

--- a/charts/stable/grafana.yml
+++ b/charts/stable/grafana.yml
@@ -1,1 +1,1 @@
-version: 2.2.5
+version: 3.5.11

--- a/charts/stable/nginx-ingress.yml
+++ b/charts/stable/nginx-ingress.yml
@@ -1,2 +1,2 @@
-version: 1.3.1
 gitUrl: https://github.com/helm/charts/tree/master/stable/nginx-ingress
+version: 1.10.2

--- a/charts/stable/prometheus.yml
+++ b/charts/stable/prometheus.yml
@@ -1,1 +1,1 @@
-version: 8.10.3
+version: 8.14.3

--- a/docker/gcr.io/jenkinsxio/builder-dlang.yml
+++ b/docker/gcr.io/jenkinsxio/builder-dlang.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-go-maven.yml
+++ b/docker/gcr.io/jenkinsxio/builder-go-maven.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-go.yml
+++ b/docker/gcr.io/jenkinsxio/builder-go.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-gradle.yml
+++ b/docker/gcr.io/jenkinsxio/builder-gradle.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-gradle4.yml
+++ b/docker/gcr.io/jenkinsxio/builder-gradle4.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-gradle5-java11.yml
+++ b/docker/gcr.io/jenkinsxio/builder-gradle5-java11.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-gradle5.yml
+++ b/docker/gcr.io/jenkinsxio/builder-gradle5.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-jx.yml
+++ b/docker/gcr.io/jenkinsxio/builder-jx.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-maven-32.yml
+++ b/docker/gcr.io/jenkinsxio/builder-maven-32.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-maven-java11.yml
+++ b/docker/gcr.io/jenkinsxio/builder-maven-java11.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-maven-nodejs.yml
+++ b/docker/gcr.io/jenkinsxio/builder-maven-nodejs.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-maven.yml
+++ b/docker/gcr.io/jenkinsxio/builder-maven.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/docker/gcr.io/jenkinsxio/builder-nodejs.yml
+++ b/docker/gcr.io/jenkinsxio/builder-nodejs.yml
@@ -1,1 +1,1 @@
-version: 0.1.549
+version: 0.1.576

--- a/jenkins-x-boot-local.yml
+++ b/jenkins-x-boot-local.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-eksclassic.yml
+++ b/jenkins-x-eksclassic.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-ekstekton.yml
+++ b/jenkins-x-ekstekton.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-gitops.yml
+++ b/jenkins-x-gitops.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-helm3.yml
+++ b/jenkins-x-helm3.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-ng.yml
+++ b/jenkins-x-ng.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-prow.yml
+++ b/jenkins-x-prow.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-static-gke-us-east1-b.yml
+++ b/jenkins-x-static-gke-us-east1-b.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-static.yml
+++ b/jenkins-x-static.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-tekton.yml
+++ b/jenkins-x-tekton.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-terraform.yml
+++ b/jenkins-x-terraform.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-terraform:0.1.549
+          image: gcr.io/jenkinsxio/builder-terraform:0.1.576
         stages:
           - name: ci
             steps:

--- a/jenkins-x-tiller.yml
+++ b/jenkins-x-tiller.yml
@@ -4,7 +4,7 @@ pipelineConfig:
     pullRequest:
       pipeline:
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:0.1.549
+          image: gcr.io/jenkinsxio/builder-go-maven:0.1.576
         stages:
           - name: ci
             steps:


### PR DESCRIPTION
change  to version change `bitnami/external-dns` to version `2.3.1`
change `jenkins-x/jenkins-x-platform` to version `2.0.851`
change `jenkins-x/jx-build-templates` to version `0.0.794`
change `jenkins-x/prow` to version `0.0.920`
change `stable/external-dns` to version `2.3.1`
change `stable/grafana` to version `3.5.11`
change `stable/nginx-ingress` to version `1.10.2`
change `stable/prometheus` to version `8.14.3`
