### PR TITLE
fix: Move boot config location

### DIFF
--- a/git/github.com/cloudbees/cloudbees-jenkins-x-boot-config.yml
+++ b/git/github.com/cloudbees/cloudbees-jenkins-x-boot-config.yml
@@ -1,0 +1,2 @@
+version: 1.0.1
+gitUrl: https://github.com/cloudbees/cloudbees-jenkins-x-boot-config


### PR DESCRIPTION
Signed-off-by: Mark Cox <markcox20@hotmail.com>

The path of the config file needs to mirror the gitUrl for the the version resolver to work correctly