### PR TITLE
fix: change the path format of the tests reports

### DIFF
--- a/jenkins-x-boot-gke.yml
+++ b/jenkins-x-boot-gke.yml
@@ -58,5 +58,6 @@ pipelineConfig:
               - name: stash_report
                 command: jx/bdd/boot-gke/report.sh
                 args:
+                  - "/workspace/source/reports"
                   - "/workspace/source/reports/bdd_boot_gke_report.html"
 

--- a/jx/bdd/boot-gke/report.sh
+++ b/jx/bdd/boot-gke/report.sh
@@ -17,5 +17,5 @@ jx step stash \
     -c tests \
     --basedir "${BASEDIR}" \
     -p "${REPORT}" \
-    --bucket-url gs://cjxd-release-logs
+    --bucket-url gs://cjxd-release-logs \
     -t "reports/${DATE}"

--- a/jx/bdd/boot-gke/report.sh
+++ b/jx/bdd/boot-gke/report.sh
@@ -2,16 +2,20 @@
 set -euo pipefail
 set -x
 
-if [ $# -ne 1 ]; then
-    echo "Please provide the report file"
+if [ $# -ne 2 ]; then
+    echo "Please provide the base dir and report file"
     exit -1
 fi
-REPORT=$1
+BASEDIR=$1
+REPORT=$2
+DATE=$(date '+%F')
 
 # activate the GCP service account before uploading the report
 gcloud auth activate-service-account --key-file $GKE_SA
 
 jx step stash \
     -c tests \
+    --basedir "${BASEDIR}" \
     -p "${REPORT}" \
     --bucket-url gs://cjxd-release-logs
+    -t "reports/${DATE}"


### PR DESCRIPTION
The path format is now `cjxd-release-logs/reports/<date>/bdd_boot_gke_report.html`.