### PR TITLE
fix: Test UI during version stream tests

### DIFF
--- a/jenkins-x-boot-gke-vault.yml
+++ b/jenkins-x-boot-gke-vault.yml
@@ -27,7 +27,7 @@ pipelineConfig:
                 name: test-jenkins-user 
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:2.0.881-233
+          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1001-331
         stages:
           - name: ci
             options:
@@ -47,7 +47,6 @@ pipelineConfig:
                 name: runci
 
               - name: generate-report
-                image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.881-233
                 command: jx
                 args:
                   - step

--- a/jenkins-x-boot-gke.yml
+++ b/jenkins-x-boot-gke.yml
@@ -21,7 +21,7 @@ pipelineConfig:
                 name: test-jenkins-user 
                 key: password
         agent:
-          image: gcr.io/jenkinsxio/builder-go-maven:2.0.881-233
+          image: gcr.io/jenkinsxio/builder-go-nodejs:2.0.1001-331
         stages:
           - name: ci
             options:
@@ -41,7 +41,6 @@ pipelineConfig:
                 name: runci
 
               - name: generate-report
-                image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.881-233
                 command: jx
                 args:
                   - step

--- a/jx/bdd/boot-gke-vault/ci.sh
+++ b/jx/bdd/boot-gke-vault/ci.sh
@@ -101,5 +101,6 @@ jx step bdd \
     --tests install \
     --tests test-verify-pods \
     --tests test-create-spring \
-    --tests test-supported-quickstarts 
+    --tests test-supported-quickstarts \
+    --tests test-app-lifecycle
     # --tests test-import # fails with vault

--- a/jx/bdd/boot-gke/ci.sh
+++ b/jx/bdd/boot-gke/ci.sh
@@ -93,4 +93,5 @@ jx step bdd \
     --tests test-verify-pods \
     --tests test-create-spring \
     --tests test-supported-quickstarts \
-    --tests test-import
+    --tests test-import \
+    --tests test-app-lifecycle


### PR DESCRIPTION
Had to switch to the `builder-go-nodejs` image as well, which didn't
exist as of last release, so I used the upstream binary equivalent to
our RCs, so far as I'm aware.

fixes https://github.com/cloudbees/cloudbees-jenkins-x-distro/issues/115

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>