### PR TITLE
chore: Update ci.sh for import/qs with local creds

### DIFF
--- a/jx/bdd/boot-gke-vault/ci.sh
+++ b/jx/bdd/boot-gke-vault/ci.sh
@@ -12,10 +12,15 @@ export BUILD_NUMBER="$BUILD_ID"
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
-mkdir -p $JX_HOME
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
 
 jx --version
-jx step git credentials
+
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 # setup GCP service account
 gcloud auth activate-service-account --key-file $GKE_SA

--- a/jx/bdd/boot-gke/ci.sh
+++ b/jx/bdd/boot-gke/ci.sh
@@ -12,10 +12,15 @@ export BUILD_NUMBER="$BUILD_ID"
 JX_HOME="/tmp/jxhome"
 KUBECONFIG="/tmp/jxhome/config"
 
-mkdir -p $JX_HOME
+# lets avoid the git/credentials causing confusion during the test
+export XDG_CONFIG_HOME=$JX_HOME
+
+mkdir -p $JX_HOME/git
 
 jx --version
-jx step git credentials
+
+# replace the credentials file with a single user entry
+echo "https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com" > $JX_HOME/git/credentials
 
 gcloud auth activate-service-account --key-file $GKE_SA
 


### PR DESCRIPTION
Once https://github.com/jenkins-x/jx/pull/6199 is merged and that jx version is used here, import/create quickstart will fail without this change, so let's get ahead of things a bit. =)