### PR TITLE
fix: Improve test TLS domain assignment logic

### DIFF
--- a/jx/bdd/boot-gke-vault/ci.sh
+++ b/jx/bdd/boot-gke-vault/ci.sh
@@ -62,9 +62,16 @@ if [[ -n "${PULL_PULL_SHA}" ]]; then
 fi
 
 
-# Rotate the domain to avoid cert-manager API rate limit
+# Rotate the domain to avoid cert-manager API rate limit and collisions by combining minute and day of year to generate
+# a number between 1 and 12 that will effectively rotate every 12 minutes from a different starting point every 12 days.
 if [[ "${DOMAIN_ROTATION}" == "true" ]]; then
-    SHARD=$(date +"%l" | xargs)
+    MIN=$(date +"%-M" | xargs)
+    DOY=$(date +"%-j" | xargs)
+    SHARD=$(((MIN + DOY) % 12))
+    # If we end up at 0, then roll back over to 12.
+    if [[ $SHARD -eq 0 ]]; then
+        SHARD=12
+    fi
     DOMAIN="${DOMAIN_PREFIX}${SHARD}${DOMAIN_SUFFIX}"
     if [[ -z "${DOMAIN}" ]]; then
         echo "Domain rotation enabled. Please set DOMAIN_PREFIX and DOMAIN_SUFFIX environment variables" 


### PR DESCRIPTION
Specifically, add the minute of the hour to the day of the year and mod that by 12 to get the domain number (with 0 being replaced by 12). This will give us a different domain every twelve minutes, with the starting point of the rotation changing every day so that we don't end up using the same domain for every cronjob run.

This way, we avoid rate limit issues by using the same domain for the same window each day, as we do currently, and we get a different domain more frequently, decreasing the chances of two PRs stomping on each other.

/assign @daveconde 
/assign @dgozalo 