### PR TITLE
chore: Run less import/quickstart tests

### DIFF
--- a/jx/bdd/boot-eks/ci.sh
+++ b/jx/bdd/boot-eks/ci.sh
@@ -108,5 +108,5 @@ jx step bdd \
     --tests install \
     --tests test-verify-pods \
     --tests test-create-spring \
-    --tests test-supported-quickstarts \
-    --tests test-import
+    --tests test-quickstart-golang-http \
+    --tests test-import-node-http

--- a/jx/bdd/boot-gke-vault/ci.sh
+++ b/jx/bdd/boot-gke-vault/ci.sh
@@ -111,5 +111,5 @@ jx step bdd \
     --tests install \
     --tests test-verify-pods \
     --tests test-create-spring \
-    --tests test-supported-quickstarts
+    --tests test-quickstart-node-http
     # --tests test-import # fails with vault

--- a/jx/bdd/boot-gke/ci.sh
+++ b/jx/bdd/boot-gke/ci.sh
@@ -95,6 +95,6 @@ jx step bdd \
     --tests install \
     --tests test-verify-pods \
     --tests test-create-spring \
-    --tests test-supported-quickstarts \
-    --tests test-import \
+    --tests test-quickstart-spring-boot-http-gradle \
+    --tests test-import-golang-http-from-jenkins-x-yml \
     --tests test-app-lifecycle

--- a/jx/bdd/helm3/ci.sh
+++ b/jx/bdd/helm3/ci.sh
@@ -54,4 +54,4 @@ jx step bdd \
     --tests test-app-lifecycle \
     --tests test-create-spring \
     --tests test-quickstart-golang-http \
-    --tests test-import
+    --tests test-import-spring-boot-rest-prometheus

--- a/jx/bdd/terraform-static/ci.sh
+++ b/jx/bdd/terraform-static/ci.sh
@@ -54,4 +54,4 @@ jx step bdd \
     --tests test-app-lifecycle \
     --tests test-create-spring \
     --tests test-quickstart-golang-http \
-    --tests test-import
+    --tests test-import-spring-boot-http-gradle

--- a/jx/bdd/terraform-tekton/ci.sh
+++ b/jx/bdd/terraform-tekton/ci.sh
@@ -53,5 +53,5 @@ jx step bdd \
     --tests test-upgrade-ingress \
     --tests test-app-lifecycle \
     --tests test-create-spring \
-    --tests test-quickstart-golang-http \
-    --tests test-import
+    --tests test-quickstart-node-http \
+    --tests test-import-golang-http-from-jenkins-x-yml


### PR DESCRIPTION
For the majority of bdd test contexts within the CJXD version stream, we would attempt to run the full quickstart/import tests. I suspect this increased the time our builds took significantly.

From now on, we run only a single quickstart/import test within each test. So we can improve the length of time our build takes.

Fixes https://github.com/cloudbees/cloudbees-jenkins-x-distro/issues/196